### PR TITLE
4.4 setting up the version catalog - Gradle Dependency fixes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,7 +41,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
+        kotlinCompilerExtensionVersion = "1.5.10"
     }
     packaging {
         resources {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,8 @@ dependencies {
     implementation(libs.coil.compose)
 
     // Compose
+    val composeBom = platform(libs.androidx.compose.bom)
+    implementation(composeBom)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.compose.ui)
@@ -75,6 +77,7 @@ dependencies {
     api(libs.core)
 
     testImplementation(libs.junit)
+    androidTestImplementation(composeBom)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)


### PR DESCRIPTION
After watching video 4.4 Setting up the Version Catalog, there are 2 gradle issues when trying to run the app:
1. Unable to resolve compose dependencies in the app module
2. Incompatible versions between Kotlin and the Compose Compiler

Fixes
1. https://developer.android.com/develop/ui/compose/bom#does_the_bom_work_with_version_catalogs
2. https://developer.android.com/jetpack/androidx/releases/compose-kotlin

I assume these will be made moot by later videos in the course, but thought it'd help if anyone is trying to run the app to verify correctness of their gradle setup after this video :)